### PR TITLE
Faster LRP rules on Dense layers

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -58,17 +58,15 @@ rules = Dict(
     "GammaRule" => GammaRule(),
     "ZBoxRule" => ZBoxRule(),
 )
-rulenames = [k for k in keys(rules)]
 
 test_rule(rule, layer, aₖ, Rₖ₊₁) = rule(layer, aₖ, Rₖ₊₁) # for use with @benchmarkable macro
 
+SUITE["Layer"] = BenchmarkGroup([k for k in keys(layers)])
 for (layername, (layer, aₖ)) in layers
-    SUITE[layername] = BenchmarkGroup(rulenames)
-    Rₖ₊₁ = layer(aₖ)
+    SUITE["Layer"][layername] = BenchmarkGroup([k for k in keys(rules)])
 
+    Rₖ₊₁ = layer(aₖ)
     for (rulename, rule) in rules
-        SUITE[layername][rulename] = BenchmarkGroup(["dispatch", "AD fallback"])
-        SUITE[layername][rulename]["dispatch"] = @benchmarkable test_rule($(rule), $(layer), $(aₖ), $(Rₖ₊₁))
-        SUITE[layername][rulename]["AD fallback"] = @benchmarkable test_rule($(rule), $(TestWrapper(layer)), $(aₖ), $(Rₖ₊₁))
+        SUITE["Layer"][layername][rulename] = @benchmarkable test_rule($(rule), $(layer), $(aₖ), $(Rₖ₊₁))
     end
 end

--- a/docs/literate/example.jl
+++ b/docs/literate/example.jl
@@ -89,9 +89,8 @@ heatmap(expl)
 # The rule has to be of type `AbstractLRPRule`.
 struct MyCustomLRPRule <: AbstractLRPRule end
 
-# It is then possible to dispatch on the utility functions [`modify_layer`](@ref),
-# [`modify_params`](@ref) and [`modify_denominator`](@ref) with our rule type
-# `MyCustomLRPRule` to define custom rules without writing boilerplate code.
+# It is then possible to dispatch on the utility functions  [`modify_params`](@ref) and [`modify_denominator`](@ref)
+# with our rule type `MyCustomLRPRule` to define custom rules without writing boilerplate code.
 function modify_params(::MyCustomLRPRule, W, b)
     ρW = W + 0.1 * relu.(W)
     return ρW, b

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -25,7 +25,6 @@ ZBoxRule
 ## Custom rules 
 These utilities can be used to define custom rules without writing boilerplate code:
 ```@docs
-modify_layer
 modify_params
 modify_denominator
 ```

--- a/src/ExplainabilityMethods.jl
+++ b/src/ExplainabilityMethods.jl
@@ -31,7 +31,7 @@ export LRP, LRPZero, LRPEpsilon, LRPGamma
 export AbstractLRPRule
 export LRP_CONFIG
 export ZeroRule, EpsilonRule, GammaRule, ZBoxRule
-export modify_layer, modify_params, modify_denominator
+export modify_params, modify_denominator
 export check_model
 
 # heatmapping

--- a/src/flux.jl
+++ b/src/flux.jl
@@ -1,5 +1,5 @@
 ## Group layers by type:
-const ConvLayer = Union{Conv,DepthwiseConv,ConvTranspose,CrossCor}
+const ConvLayer = Union{Conv} # TODO: DepthwiseConv, ConvTranspose, CrossCor
 const DropoutLayer = Union{Dropout,typeof(Flux.dropout),AlphaDropout}
 const ReshapingLayer = Union{typeof(Flux.flatten)}
 # Pooling layers


### PR DESCRIPTION
~Towards #22:
Dispatch to a simpler Linear Algebra implementation of LRP on `Dense` layers instead of using autodiff.~

As this didn't result in any speedup, this PR will remove the tests and benchmarks that were added in preparation! 