### PR TITLE
Faster LRP rules on Dense layers 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
@@ -18,6 +19,7 @@ ColorSchemes = "3"
 Flux = "0.12"
 ImageCore = "0.8, 0.9"
 PrettyTables = "1"
+Tullio = "0.3"
 Zygote = "0.6"
 julia = "1.6"
 

--- a/src/ExplainabilityMethods.jl
+++ b/src/ExplainabilityMethods.jl
@@ -6,6 +6,7 @@ using Zygote
 using ColorSchemes
 using ImageCore
 using Base.Iterators
+using Tullio
 
 using Markdown
 using PrettyTables

--- a/src/lrp_rules.jl
+++ b/src/lrp_rules.jl
@@ -39,12 +39,8 @@ end
 
 function lrp_dense(rule, l, aₖ, Rₖ₊₁)
     ρW, ρb = modify_params(rule, get_params(l)...)
-    # Foward pass: fwp_{ij} = ρW_{ij} * aₖ_{j}
-    fwp = ρW .* transpose(aₖ)
-    z = modify_denominator(rule, sum(fwp; dims=2) + ρb) # denominator
-    # Multiply columns of `fwp` (each column corresponding to the activations from a single input neuron)
-    # by rescaled relevances `Rₖ₊₁ ./ z` of all output neurons.
-    return reshape(transpose(fwp) * (Rₖ₊₁ ./ z), size(aₖ))
+    ãₖ₊₁ = modify_denominator(rule, ρW * aₖ + ρb)
+    return @tullio Rₖ[j] := aₖ[j] * ρW[k, j] / ãₖ₊₁[k] * Rₖ₊₁[k]
 end
 
 # Other special cases that are dispatched on layer type:

--- a/src/lrp_rules.jl
+++ b/src/lrp_rules.jl
@@ -4,23 +4,27 @@
 # can be implemented by dispatching on the functions `modify_params` & `modify_denominator`,
 # which make use of the generalized LRP implementation shown in [1].
 #
-# If the relevance propagation falls outside of this scheme, a custom function
+# If the relevance propagation falls outside of this scheme, custom functions
 # ```julia
 # (::MyLRPRule)(layer, aₖ, Rₖ₊₁) = ...
+# (::MyLRPRule)(layer::MyLayer, aₖ, Rₖ₊₁) = ...
+# (::AbstractLRPRule)(layer::MyLayer, aₖ, Rₖ₊₁) = ...
 # ```
-# can be implemented. This is used for the ZBoxRule.
+# that return `Rₖ` can be implemented.
+# This is used for the ZBoxRule and for faster computations on common layers.
 #
 # References:
 # [1] G. Montavon et al., Layer-Wise Relevance Propagation: An Overview
-# [2] W. Samek et al., Explaining Deep Neural Networks and Beyond:
-#     A Review of Methods and Applications
+# [2] W. Samek et al., Explaining Deep Neural Networks and Beyond: A Review of Methods and Applications
 
 abstract type AbstractLRPRule end
 
 # This is the generic relevance propagation rule which is used for the 0, γ and ϵ rules.
 # It can be extended for new rules via `modify_denominator` and `modify_params`.
 # Since it uses autodiff, it is used as a fallback for layer types without custom implementation.
-function (rule::AbstractLRPRule)(layer, aₖ, Rₖ₊₁)
+(rule::AbstractLRPRule)(layer, aₖ, Rₖ₊₁) = lrp_autodiff(rule, layer, aₖ, Rₖ₊₁)
+
+function lrp_autodiff(rule, layer, aₖ, Rₖ₊₁)
     layerᵨ = _modify_layer(rule, layer)
     function fwpass(a)
         z = layerᵨ(a)
@@ -30,7 +34,20 @@ function (rule::AbstractLRPRule)(layer, aₖ, Rₖ₊₁)
     return aₖ .* gradient(fwpass, aₖ)[1] # Rₖ
 end
 
-# Special cases are dispatched on layer type:
+# For linear layer types such as Dense layers, using autodiff is overkill.
+(rule::AbstractLRPRule)(layer::Dense, aₖ, Rₖ₊₁) = lrp_dense(rule, layer, aₖ, Rₖ₊₁)
+
+function lrp_dense(rule, l, aₖ, Rₖ₊₁)
+    ρW, ρb = modify_params(rule, get_params(l)...)
+    # Foward pass: fwp_{ij} = ρW_{ij} * aₖ_{j}
+    fwp = ρW .* transpose(aₖ)
+    z = modify_denominator(rule, sum(fwp; dims=2) + ρb) # denominator
+    # Multiply columns of `fwp` (each column corresponding to the activations from a single input neuron)
+    # by rescaled relevances `Rₖ₊₁ ./ z` of all output neurons.
+    return reshape(transpose(fwp) * (Rₖ₊₁ ./ z), size(aₖ))
+end
+
+# Other special cases that are dispatched on layer type:
 (::AbstractLRPRule)(::DropoutLayer, aₖ, Rₖ₊₁) = Rₖ₊₁
 (::AbstractLRPRule)(::ReshapingLayer, aₖ, Rₖ₊₁) = reshape(Rₖ₊₁, size(aₖ))
 
@@ -104,12 +121,17 @@ Commonly used on the first layer for pixel input.
 struct ZBoxRule <: AbstractLRPRule end
 
 # The ZBoxRule requires its own implementation of relevance propagation.
-function (rule::ZBoxRule)(layer::Union{Dense,Conv}, aₖ, Rₖ₊₁)
+(rule::ZBoxRule)(layer::Dense, aₖ, Rₖ₊₁) = lrp_zbox(layer, aₖ, Rₖ₊₁)
+(rule::ZBoxRule)(layer::Conv, aₖ, Rₖ₊₁) = lrp_zbox(layer, aₖ, Rₖ₊₁)
+
+function lrp_zbox(layer, aₖ, Rₖ₊₁)
     W, b = get_params(layer)
     l, h = fill.(extrema(aₖ), (size(aₖ),))
 
     layer⁺ = set_params(layer, max.(0, W), max.(0, b)) # W⁺, b⁺
     layer⁻ = set_params(layer, min.(0, W), min.(0, b)) # W⁻, b⁻
+
+    l, h = fill.(extrema(aₖ), (size(aₖ),))
 
     # Forward pass
     function fwpass(a, l, h)

--- a/src/lrp_rules.jl
+++ b/src/lrp_rules.jl
@@ -131,8 +131,6 @@ function lrp_zbox(layer, aₖ, Rₖ₊₁)
     layer⁺ = set_params(layer, max.(0, W), max.(0, b)) # W⁺, b⁺
     layer⁻ = set_params(layer, min.(0, W), min.(0, b)) # W⁻, b⁻
 
-    l, h = fill.(extrema(aₖ), (size(aₖ),))
-
     # Forward pass
     function fwpass(a, l, h)
         f = layer(a)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,7 +3,8 @@
 
 Replace zero terms of a matrix `d` with `eps`.
 """
-function stabilize_denom(d; eps=1.0f-9)
+stabilize_denom(d::Real; eps=1.0f-9) = ifelse(d ≈ 0, d + sign(d) * eps, d)
+function stabilize_denom(d::AbstractArray; eps=1.0f-9)
     return d + ((d .≈ 0) + sign.(d)) * eps
 end
 


### PR DESCRIPTION
Second attempt at failed PR #28 after fixing benchmarks in PR #30.
Working towards issue #22.  

___

Adds a linear algebra implementation of LRP for `Flux.Dense` layers that skips autodiff.